### PR TITLE
fix: remove unused chrono default features to address CVE-2020-26235

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = [""]
 
 [dependencies]
 openweathermap = "0.2.4"
-chrono = "0.4.22"
+chrono = { version = "0.4.22", default-features = false, features = [] }
 chrono-tz = "0.8.0"
 iso8601-duration = "0.1.0"
 config = "0.13.2"


### PR DESCRIPTION
According to https://github.com/chronotope/chrono/pull/626
this should fix the issue from time 0.1